### PR TITLE
Removing the master-slave vocabulary

### DIFF
--- a/src/lib/mongoengine-master/docs/conf.py
+++ b/src/lib/mongoengine-master/docs/conf.py
@@ -33,8 +33,8 @@ source_suffix = '.rst'
 # The encoding of source files.
 #source_encoding = 'utf-8'
 
-# The master toctree document.
-master_doc = 'index'
+# The main toctree document.
+main_doc = 'index'
 
 # General information about the project.
 project = u'MongoEngine'

--- a/src/lib/mongoengine-master/mongoengine/connection.py
+++ b/src/lib/mongoengine-master/mongoengine/connection.py
@@ -19,7 +19,7 @@ _dbs = {}
 
 
 def register_connection(alias, name, host='localhost', port=27017,
-                        is_slave=False, read_preference=False, slaves=None,
+                        is_subordinate=False, read_preference=False, subordinates=None,
                         username=None, password=None, **kwargs):
     """Add a connection.
 
@@ -28,12 +28,12 @@ def register_connection(alias, name, host='localhost', port=27017,
     :param name: the name of the specific database to use
     :param host: the host name of the :program:`mongod` instance to connect to
     :param port: the port that the :program:`mongod` instance is running on
-    :param is_slave: whether the connection can act as a slave
+    :param is_subordinate: whether the connection can act as a subordinate
       ** Depreciated pymongo 2.0.1+
     :param read_preference: The read preference for the collection
        ** Added pymongo 2.1
-    :param slaves: a list of aliases of slave connections; each of these must
-        be a registered connection that has :attr:`is_slave` set to ``True``
+    :param subordinates: a list of aliases of subordinate connections; each of these must
+        be a registered connection that has :attr:`is_subordinate` set to ``True``
     :param username: username to authenticate with
     :param password: password to authenticate with
     :param kwargs: allow ad-hoc parameters to be passed into the pymongo driver
@@ -45,8 +45,8 @@ def register_connection(alias, name, host='localhost', port=27017,
         'name': name,
         'host': host,
         'port': port,
-        'is_slave': is_slave,
-        'slaves': slaves or [],
+        'is_subordinate': is_subordinate,
+        'subordinates': subordinates or [],
         'username': username,
         'password': password,
         'read_preference': read_preference
@@ -99,17 +99,17 @@ def get_connection(alias=DEFAULT_CONNECTION_NAME, reconnect=False):
 
         if hasattr(pymongo, 'version_tuple'):  # Support for 2.1+
             conn_settings.pop('name', None)
-            conn_settings.pop('slaves', None)
-            conn_settings.pop('is_slave', None)
+            conn_settings.pop('subordinates', None)
+            conn_settings.pop('is_subordinate', None)
             conn_settings.pop('username', None)
             conn_settings.pop('password', None)
         else:
-            # Get all the slave connections
-            if 'slaves' in conn_settings:
-                slaves = []
-                for slave_alias in conn_settings['slaves']:
-                    slaves.append(get_connection(slave_alias))
-                conn_settings['slaves'] = slaves
+            # Get all the subordinate connections
+            if 'subordinates' in conn_settings:
+                subordinates = []
+                for subordinate_alias in conn_settings['subordinates']:
+                    subordinates.append(get_connection(subordinate_alias))
+                conn_settings['subordinates'] = subordinates
                 conn_settings.pop('read_preference', None)
 
         connection_class = MongoClient

--- a/src/lib/mongoengine-master/mongoengine/queryset.py
+++ b/src/lib/mongoengine-master/mongoengine/queryset.py
@@ -107,7 +107,7 @@ class QueryTreeTransformerVisitor(QNodeVisitor):
         if combination.operation == combination.AND:
             # MongoDB doesn't allow us to have too many $or operations in our
             # queries, so the aim is to move the ORs up the tree to one
-            # 'master' $or. Firstly, we must find all the necessary parts (part
+            # 'main' $or. Firstly, we must find all the necessary parts (part
             # of an AND combination or just standard Q object), and store them
             # separately from the OR parts.
             or_groups = []
@@ -350,7 +350,7 @@ class QuerySet(object):
         self._snapshot = False
         self._timeout = True
         self._class_check = True
-        self._slave_okay = False
+        self._subordinate_okay = False
         self._iter = False
         self._scalar = []
 
@@ -373,7 +373,7 @@ class QuerySet(object):
 
         copy_props = ('_initial_query', '_query_obj', '_where_clause',
                     '_loaded_fields', '_ordering', '_snapshot',
-                    '_timeout', '_limit', '_skip', '_slave_okay', '_hint')
+                    '_timeout', '_limit', '_skip', '_subordinate_okay', '_hint')
 
         for prop in copy_props:
             val = getattr(self, prop)
@@ -407,7 +407,7 @@ class QuerySet(object):
         self._collection.ensure_index(fields, **index_spec)
         return self
 
-    def __call__(self, q_obj=None, class_check=True, slave_okay=False, **query):
+    def __call__(self, q_obj=None, class_check=True, subordinate_okay=False, **query):
         """Filter the selected documents by calling the
         :class:`~mongoengine.queryset.QuerySet` with a query.
 
@@ -417,7 +417,7 @@ class QuerySet(object):
             objects, only the last one will be used
         :param class_check: If set to False bypass class name check when
             querying collection
-        :param slave_okay: if True, allows this query to be run against a
+        :param subordinate_okay: if True, allows this query to be run against a
             replica secondary.
         :param query: Django-style query keyword arguments
         """
@@ -592,7 +592,7 @@ class QuerySet(object):
         cursor_args = {
             'snapshot': self._snapshot,
             'timeout': self._timeout,
-            'slave_okay': self._slave_okay
+            'subordinate_okay': self._subordinate_okay
         }
         if self._loaded_fields:
             cursor_args['fields'] = self._loaded_fields.as_dict()
@@ -1337,12 +1337,12 @@ class QuerySet(object):
         self._timeout = enabled
         return self
 
-    def slave_okay(self, enabled):
-        """Enable or disable the slave_okay when querying.
+    def subordinate_okay(self, enabled):
+        """Enable or disable the subordinate_okay when querying.
 
-        :param enabled: whether or not the slave_okay is enabled
+        :param enabled: whether or not the subordinate_okay is enabled
         """
-        self._slave_okay = enabled
+        self._subordinate_okay = enabled
         return self
 
     def delete(self, safe=False):

--- a/src/lib/mongoengine-master/mongoengine/queryset/base.py
+++ b/src/lib/mongoengine-master/mongoengine/queryset/base.py
@@ -53,7 +53,7 @@ class BaseQuerySet(object):
         self._snapshot = False
         self._timeout = True
         self._class_check = True
-        self._slave_okay = False
+        self._subordinate_okay = False
         self._read_preference = None
         self._iter = False
         self._scalar = []
@@ -75,7 +75,7 @@ class BaseQuerySet(object):
         self._skip = None
         self._hint = -1  # Using -1 as None is a valid value for hint
 
-    def __call__(self, q_obj=None, class_check=True, slave_okay=False,
+    def __call__(self, q_obj=None, class_check=True, subordinate_okay=False,
                  read_preference=None, **query):
         """Filter the selected documents by calling the
         :class:`~mongoengine.queryset.QuerySet` with a query.
@@ -86,7 +86,7 @@ class BaseQuerySet(object):
             objects, only the last one will be used
         :param class_check: If set to False bypass class name check when
             querying collection
-        :param slave_okay: if True, allows this query to be run against a
+        :param subordinate_okay: if True, allows this query to be run against a
             replica secondary.
         :params read_preference: if set, overrides connection-level
             read_preference from `ReplicaSetConnection`.
@@ -541,7 +541,7 @@ class BaseQuerySet(object):
 
         copy_props = ('_mongo_query', '_initial_query', '_none', '_query_obj',
                       '_where_clause', '_loaded_fields', '_ordering', '_snapshot',
-                      '_timeout', '_class_check', '_slave_okay', '_read_preference',
+                      '_timeout', '_class_check', '_subordinate_okay', '_read_preference',
                       '_iter', '_scalar', '_as_pymongo', '_as_pymongo_coerce',
                       '_limit', '_skip', '_hint', '_auto_dereference')
 
@@ -766,13 +766,13 @@ class BaseQuerySet(object):
         queryset._timeout = enabled
         return queryset
 
-    def slave_okay(self, enabled):
-        """Enable or disable the slave_okay when querying.
+    def subordinate_okay(self, enabled):
+        """Enable or disable the subordinate_okay when querying.
 
-        :param enabled: whether or not the slave_okay is enabled
+        :param enabled: whether or not the subordinate_okay is enabled
         """
         queryset = self.clone()
-        queryset._slave_okay = enabled
+        queryset._subordinate_okay = enabled
         return queryset
 
     def read_preference(self, read_preference):
@@ -1165,7 +1165,7 @@ class BaseQuerySet(object):
         if self._read_preference is not None:
             cursor_args['read_preference'] = self._read_preference
         else:
-            cursor_args['slave_okay'] = self._slave_okay
+            cursor_args['subordinate_okay'] = self._subordinate_okay
         if self._loaded_fields:
             cursor_args['fields'] = self._loaded_fields.as_dict()
         return cursor_args

--- a/src/lib/mongoengine-master/tests/queryset/queryset.py
+++ b/src/lib/mongoengine-master/tests/queryset/queryset.py
@@ -787,8 +787,8 @@ class QuerySetTest(unittest.TestCase):
 
             self.assertEqual(q, 3)
 
-    def test_slave_okay(self):
-        """Ensures that a query can take slave_okay syntax
+    def test_subordinate_okay(self):
+        """Ensures that a query can take subordinate_okay syntax
         """
         person1 = self.Person(name="User A", age=20)
         person1.save()
@@ -796,7 +796,7 @@ class QuerySetTest(unittest.TestCase):
         person2.save()
 
         # Retrieve the first person from the database
-        person = self.Person.objects.slave_okay(True).first()
+        person = self.Person.objects.subordinate_okay(True).first()
         self.assertTrue(isinstance(person, self.Person))
         self.assertEqual(person.name, "User A")
         self.assertEqual(person.age, 20)
@@ -807,23 +807,23 @@ class QuerySetTest(unittest.TestCase):
         p = self.Person.objects
         # Check default
         self.assertEqual(p._cursor_args,
-                {'snapshot': False, 'slave_okay': False, 'timeout': True})
+                {'snapshot': False, 'subordinate_okay': False, 'timeout': True})
 
-        p = p.snapshot(False).slave_okay(False).timeout(False)
+        p = p.snapshot(False).subordinate_okay(False).timeout(False)
         self.assertEqual(p._cursor_args,
-                {'snapshot': False, 'slave_okay': False, 'timeout': False})
+                {'snapshot': False, 'subordinate_okay': False, 'timeout': False})
 
-        p = p.snapshot(True).slave_okay(False).timeout(False)
+        p = p.snapshot(True).subordinate_okay(False).timeout(False)
         self.assertEqual(p._cursor_args,
-                {'snapshot': True, 'slave_okay': False, 'timeout': False})
+                {'snapshot': True, 'subordinate_okay': False, 'timeout': False})
 
-        p = p.snapshot(True).slave_okay(True).timeout(False)
+        p = p.snapshot(True).subordinate_okay(True).timeout(False)
         self.assertEqual(p._cursor_args,
-                {'snapshot': True, 'slave_okay': True, 'timeout': False})
+                {'snapshot': True, 'subordinate_okay': True, 'timeout': False})
 
-        p = p.snapshot(True).slave_okay(True).timeout(True)
+        p = p.snapshot(True).subordinate_okay(True).timeout(True)
         self.assertEqual(p._cursor_args,
-                         {'snapshot': True, 'slave_okay': True, 'timeout': True})
+                         {'snapshot': True, 'subordinate_okay': True, 'timeout': True})
 
     def test_repeated_iteration(self):
         """Ensure that QuerySet rewinds itself one iteration finishes.

--- a/src/lib/mongoengine-master/tests/test_queryset.py
+++ b/src/lib/mongoengine-master/tests/test_queryset.py
@@ -643,8 +643,8 @@ class QuerySetTest(unittest.TestCase):
 
             self.assertEqual(q, 3)
 
-    def test_slave_okay(self):
-        """Ensures that a query can take slave_okay syntax
+    def test_subordinate_okay(self):
+        """Ensures that a query can take subordinate_okay syntax
         """
         person1 = self.Person(name="User A", age=20)
         person1.save()
@@ -652,7 +652,7 @@ class QuerySetTest(unittest.TestCase):
         person2.save()
 
         # Retrieve the first person from the database
-        person = self.Person.objects.slave_okay(True).first()
+        person = self.Person.objects.subordinate_okay(True).first()
         self.assertTrue(isinstance(person, self.Person))
         self.assertEqual(person.name, "User A")
         self.assertEqual(person.age, 20)
@@ -663,23 +663,23 @@ class QuerySetTest(unittest.TestCase):
         p = self.Person.objects
         # Check default
         self.assertEqual(p._cursor_args,
-                {'snapshot': False, 'slave_okay': False, 'timeout': True})
+                {'snapshot': False, 'subordinate_okay': False, 'timeout': True})
 
-        p.snapshot(False).slave_okay(False).timeout(False)
+        p.snapshot(False).subordinate_okay(False).timeout(False)
         self.assertEqual(p._cursor_args,
-                {'snapshot': False, 'slave_okay': False, 'timeout': False})
+                {'snapshot': False, 'subordinate_okay': False, 'timeout': False})
 
-        p.snapshot(True).slave_okay(False).timeout(False)
+        p.snapshot(True).subordinate_okay(False).timeout(False)
         self.assertEqual(p._cursor_args,
-                {'snapshot': True, 'slave_okay': False, 'timeout': False})
+                {'snapshot': True, 'subordinate_okay': False, 'timeout': False})
 
-        p.snapshot(True).slave_okay(True).timeout(False)
+        p.snapshot(True).subordinate_okay(True).timeout(False)
         self.assertEqual(p._cursor_args,
-                {'snapshot': True, 'slave_okay': True, 'timeout': False})
+                {'snapshot': True, 'subordinate_okay': True, 'timeout': False})
 
-        p.snapshot(True).slave_okay(True).timeout(True)
+        p.snapshot(True).subordinate_okay(True).timeout(True)
         self.assertEqual(p._cursor_args,
-                {'snapshot': True, 'slave_okay': True, 'timeout': True})
+                {'snapshot': True, 'subordinate_okay': True, 'timeout': True})
 
     def test_repeated_iteration(self):
         """Ensure that QuerySet rewinds itself one iteration finishes.


### PR DESCRIPTION
For diversity reasons, it would be nice to try to avoid 'master' and 'slave' terminology in this repository which can be associated to slavery. The master-slave terminology could be problematic for people in several countries which has the history of slavery like Romania, USA and many others. Thank you for considering the proposal. Let me know if any changes in the PR are needed, I would be happy to implement them.